### PR TITLE
Update reindex.sh to specify /bin/bash as the interpreter.

### DIFF
--- a/reindex.sh
+++ b/reindex.sh
@@ -1,5 +1,6 @@
-#!/bin/sh
-
+#!/bin/bash
+# This script requires bash, on some systems like Ubuntu, /bin/sh redirects to a different shell
+# such as dash, which will not properly run this script in it's current iteration.
 ########################################## Settings ##########################################
 # username - Admin user on the Jira Server
 username="jason.hensler"


### PR DESCRIPTION
This script requires bash, on some systems like Ubuntu, /bin/sh redirects to a different shell such as dash, which will not properly run this script in it's current iteration.
